### PR TITLE
Adding ovn4nfv-k8s-plugin in kubespray

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.3.0
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.0.1
   - [multus](https://github.com/intel/multus-cni) v3.6.0
-  - [ovn4nfv](https://github.com/opnfv/ovn4nfv-k8s-plugin) v1.0.0
+  - [ovn4nfv](https://github.com/opnfv/ovn4nfv-k8s-plugin) v1.1.0
   - [weave](https://github.com/weaveworks/weave) v2.7.0
 - Application
   - [ambassador](https://github.com/datawire/ambassador): v1.5

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11
   - [rbd-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.1-k8s1.11
   - [cert-manager](https://github.com/jetstack/cert-manager) v0.15.2
-  - [coredns](https://github.com/coredns/coredns) v1.6.7
+  - [coredns](https://github.com/coredns/coredns) v1.7.0
   - [ingress-nginx](https://github.com/kubernetes/ingress-nginx) v0.32.0
 
 Note: The list of validated [docker versions](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#docker) is 1.13.1, 17.03, 17.06, 17.09, 18.06, 18.09 and 19.03. The recommended docker version is 19.03. The kubelet might break on docker's non-standard version numbering (it no longer uses semantic versioning). To ensure auto-updates don't break your cluster look into e.g. yum versionlock plugin or apt pin).

--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ Note: Upstart/SysV init based OS types are not supported.
   - [cni-plugins](https://github.com/containernetworking/plugins) v0.8.6
   - [calico](https://github.com/projectcalico/calico) v3.15.1
   - [canal](https://github.com/projectcalico/canal) (given calico/flannel versions)
-  - [cilium](https://github.com/cilium/cilium) v1.8.1
+  - [cilium](https://github.com/cilium/cilium) v1.8.2
   - [contiv](https://github.com/contiv/install) v1.2.1
   - [flanneld](https://github.com/coreos/flannel) v0.12.0
   - [kube-ovn](https://github.com/alauda/kube-ovn) v1.3.0
   - [kube-router](https://github.com/cloudnativelabs/kube-router) v1.0.1
   - [multus](https://github.com/intel/multus-cni) v3.6.0
   - [ovn4nfv](https://github.com/opnfv/ovn4nfv-k8s-plugin) v1.0.0
-  - [weave](https://github.com/weaveworks/weave) v2.6.5
+  - [weave](https://github.com/weaveworks/weave) v2.7.0
 - Application
   - [ambassador](https://github.com/datawire/ambassador): v1.5
   - [cephfs-provisioner](https://github.com/kubernetes-incubator/external-storage) v2.1.0-k8s1.11

--- a/contrib/inventory_builder/inventory.py
+++ b/contrib/inventory_builder/inventory.py
@@ -238,7 +238,7 @@ class KubesprayInventory(object):
             return [ip_address(ip).exploded for ip in range(start, end + 1)]
 
         for host in hosts:
-            if '-' in host and not host.startswith('-'):
+            if '-' in host and not (host.startswith('-') or host[0].isalpha()):
                 start, end = host.strip().split('-')
                 try:
                     reworked_hosts.extend(ips(start, end))

--- a/contrib/terraform/openstack/kubespray.tf
+++ b/contrib/terraform/openstack/kubespray.tf
@@ -51,6 +51,7 @@ module "compute" {
   node_root_volume_size_in_gb                  = var.node_root_volume_size_in_gb
   gfs_root_volume_size_in_gb                   = var.gfs_root_volume_size_in_gb
   gfs_volume_size_in_gb                        = var.gfs_volume_size_in_gb
+  master_volume_type                           = var.master_volume_type
   public_key_path                              = var.public_key_path
   image                                        = var.image
   image_gfs                                    = var.image_gfs

--- a/contrib/terraform/openstack/modules/compute/main.tf
+++ b/contrib/terraform/openstack/modules/compute/main.tf
@@ -167,6 +167,7 @@ resource "openstack_compute_instance_v2" "k8s_master" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true
@@ -215,6 +216,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_etcd" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true
@@ -303,6 +305,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true
@@ -346,6 +349,7 @@ resource "openstack_compute_instance_v2" "k8s_master_no_floating_ip_no_etcd" {
       uuid                  = data.openstack_images_image_v2.vm_image.id
       source_type           = "image"
       volume_size           = var.master_root_volume_size_in_gb
+      volume_type           = var.master_volume_type
       boot_index            = 0
       destination_type      = "volume"
       delete_on_termination = true

--- a/contrib/terraform/openstack/modules/compute/variables.tf
+++ b/contrib/terraform/openstack/modules/compute/variables.tf
@@ -38,6 +38,8 @@ variable "gfs_root_volume_size_in_gb" {}
 
 variable "gfs_volume_size_in_gb" {}
 
+variable "master_volume_type" {}
+
 variable "public_key_path" {}
 
 variable "image" {}

--- a/contrib/terraform/openstack/variables.tf
+++ b/contrib/terraform/openstack/variables.tf
@@ -74,6 +74,10 @@ variable "gfs_volume_size_in_gb" {
   default = 75
 }
 
+variable "master_volume_type" {
+  default = "Default"
+}
+
 variable "public_key_path" {
   description = "The path of the ssh pub key"
   default     = "~/.ssh/id_rsa.pub"

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -41,4 +41,5 @@
   * [Test cases](docs/test_cases.md)
   * [Vagrant](docs/vagrant.md)
   * [CI Matrix](docs/ci.md)
+  * [CI Setup](docs/ci-setup.md)
 * [Roadmap](docs/roadmap.md)

--- a/docs/ci-setup.md
+++ b/docs/ci-setup.md
@@ -1,0 +1,20 @@
+# CI Setup
+
+## Pipeline
+
+1. unit-tests: fast jobs for fast feedback (linting, etc...)
+2. deploy-part1: small number of jobs to test if the PR works with default settings
+3. deploy-part2: slow jobs testing different platforms, OS, settings, CNI, etc...
+4. deploy-part3: very slow jobs (upgrades, etc...)
+
+## Runners
+
+Kubespray has 3 types of GitLab runners:
+
+- packet runners: used for E2E jobs (usually long)
+- light runners: used for short lived jobs
+- auto scaling runners: used for on-demand resources, see [GitLab docs](https://docs.gitlab.com/runner/configuration/autoscale.html) for more info
+
+## Vagrant
+
+Vagrant jobs are using the [quay.io/kubespray/vagrant](/test-infra/vagrant-docker/Dockerfile) docker image with `/var/run/libvirt/libvirt-sock` exposed from the host, allowing the container to boot VMs on the host.

--- a/roles/container-engine/docker/tasks/systemd.yml
+++ b/roles/container-engine/docker/tasks/systemd.yml
@@ -25,7 +25,7 @@
     dest: /etc/systemd/system/docker.service
   register: docker_service_file
   notify: restart docker
-  when: not (ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"] or is_ostree)
+  when: not ansible_os_family in ["CoreOS", "Coreos", "Container Linux by CoreOS", "Flatcar", "Flatcar Container Linux by Kinvolk"]
 
 - name: Write docker options systemd drop-in
   template:

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -504,7 +504,7 @@ haproxy_image_tag: 2.1
 
 # Coredns version should be supported by corefile-migration (or at least work with)
 # bundle with kubeadm; if not 'basic' upgrade can sometimes fail
-coredns_version: "1.6.7"
+coredns_version: "1.7.0"
 coredns_image_repo: "{{ docker_image_repo }}/coredns/coredns"
 coredns_image_tag: "{{ coredns_version }}"
 

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -76,10 +76,10 @@ flannel_version: "v0.12.0"
 
 cni_version: "v0.8.6"
 
-weave_version: 2.6.5
+weave_version: 2.7.0
 pod_infra_version: "3.2"
 contiv_version: 1.2.1
-cilium_version: "v1.8.1"
+cilium_version: "v1.8.2"
 kube_ovn_version: "v1.3.0"
 kube_router_version: "v1.0.1"
 multus_version: "v3.6"

--- a/roles/download/defaults/main.yml
+++ b/roles/download/defaults/main.yml
@@ -84,7 +84,7 @@ kube_ovn_version: "v1.3.0"
 kube_router_version: "v1.0.1"
 multus_version: "v3.6"
 ovn4nfv_ovn_image_version: "v1.0.0"
-ovn4nfv_k8s_plugin_image_version: "v1.0.0"
+ovn4nfv_k8s_plugin_image_version: "v1.1.0"
 
 # Get kubernetes major version (i.e. 1.17.4 => 1.17)
 kube_major_version: "{{ kube_version | regex_replace('^v([0-9])+\\.([0-9]+)\\.[0-9]+', 'v\\1.\\2') }}"

--- a/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
+++ b/roles/kubernetes-apps/ingress_controller/cert_manager/tasks/main.yml
@@ -68,7 +68,7 @@
     - inventory_hostname == groups['kube-master'][0]
 
 - name: Cert Manager | Wait for Webhook pods become ready
-  shell: "{{ bin_dir }}/kubectl wait po --namespace={{ cert_manager_namespace }} --selector app=webhook --for=condition=Ready --timeout=600s"
+  command: "{{ bin_dir }}/kubectl wait po --namespace={{ cert_manager_namespace }} --selector app=webhook --for=condition=Ready --timeout=600s"
   register: cert_manager_webhook_pods_ready
   when: inventory_hostname == groups['kube-master'][0]
 

--- a/roles/kubernetes/kubeadm/handlers/main.yml
+++ b/roles/kubernetes/kubeadm/handlers/main.yml
@@ -3,13 +3,13 @@
   command: /bin/true
   notify:
     - Kubeadm | reload systemd
-    - Kubeadm | reload kubelet
+    - Kubeadm | restart kubelet
 
 - name: Kubeadm | reload systemd
   systemd:
     daemon_reload: true
 
-- name: Kubeadm | reload kubelet
+- name: Kubeadm | restart kubelet
   service:
     name: kubelet
     state: restarted

--- a/roles/kubernetes/kubeadm/tasks/main.yml
+++ b/roles/kubernetes/kubeadm/tasks/main.yml
@@ -178,5 +178,5 @@
     - etcd_kubeadm_enabled
     - kubeadm_control_plane
     - inventory_hostname not in groups['kube-master']
-    - kube_network_plugin in ["calico", "flannel", "canal", "cilium"]
+    - kube_network_plugin in ["calico", "flannel", "canal", "cilium"] or cilium_deploy_additionally | default(false) | bool
     - kube_network_plugin != "calico" or calico_datastore == "etcd"

--- a/roles/kubernetes/master/defaults/main/main.yml
+++ b/roles/kubernetes/master/defaults/main/main.yml
@@ -26,9 +26,6 @@ kube_apiserver_node_port_range: "30000-32767"
 # ETCD backend for k8s data
 kube_apiserver_storage_backend: etcd3
 
-# By default, force back to etcd2. Set to true to force etcd3 (experimental!)
-force_etcd3: false
-
 kube_etcd_cacert_file: ca.pem
 kube_etcd_cert_file: node-{{ inventory_hostname }}.pem
 kube_etcd_key_file: node-{{ inventory_hostname }}-key.pem
@@ -165,9 +162,6 @@ kube_encrypt_token: "{{ lookup('password', credentials_dir + '/kube_encrypt_toke
 kube_encryption_algorithm: "aescbc"
 # Which kubernetes resources to encrypt
 kube_encryption_resources: [secrets]
-
-# You may want to use ca.pem depending on your situation
-kube_front_proxy_ca: "front-proxy-ca.pem"
 
 # If non-empty, will use this string as identification instead of the actual hostname
 kube_override_hostname: >-

--- a/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2
+++ b/roles/kubernetes/master/templates/apiserver-audit-policy.yaml.j2
@@ -1,4 +1,4 @@
-apiVersion: audit.k8s.io/v1beta1
+apiVersion: audit.k8s.io/v1
 kind: Policy
 rules:
 {% if audit_policy_custom_rules is defined and audit_policy_custom_rules != "" %}

--- a/roles/kubernetes/node-label/tasks/main.yml
+++ b/roles/kubernetes/node-label/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: Set label to node
   command: >-
-      {{ bin_dir }}/kubectl label node {{ inventory_hostname }} {{ item }} --overwrite=true
+      {{ bin_dir }}/kubectl label node {{ kube_override_hostname | default(inventory_hostname) }} {{ item }} --overwrite=true
   loop: "{{ role_node_labels + inventory_node_labels }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   changed_when: false

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -22,6 +22,7 @@ cilium_cpu_requests: 100m
 cilium_tunnel_mode: vxlan
 # Optional features
 cilium_enable_prometheus: false
+cilium_enable_hubble_metrics: false
 # Enable if you want to make use of hostPort mappings
 cilium_enable_portmap: false
 # Monitor aggregation level (none/low/medium/maximum)

--- a/roles/network_plugin/cilium/defaults/main.yml
+++ b/roles/network_plugin/cilium/defaults/main.yml
@@ -40,3 +40,12 @@ cilium_enable_legacy_services: false
 # Deploy cilium even if kube_network_plugin is not cilium.
 # This enables to deploy cilium alongside another CNI to replace kube-proxy.
 cilium_deploy_additionally: false
+
+# Auto direct nodes routes can be used to advertise pods routes in your cluster
+# without any tunelling (with `cilium_tunnel_mode` sets to `disabled`).
+# This works only if you have a L2 connectivity between all your nodes.
+# You wil also have to specify the variable `cilium_native_routing_cidr` to
+# make this work. Please refer to the cilium documentation for more
+# information about this kind of setups.
+cilium_auto_direct_node_routes: false
+cilium_native_routing_cidr: ""

--- a/roles/network_plugin/cilium/templates/cilium-config.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-config.yml.j2
@@ -142,3 +142,6 @@ data:
   enable-legacy-services: "{{cilium_enable_legacy_services}}"
 
   kube-proxy-replacement: "{{ cilium_kube_proxy_replacement }}"
+
+  native-routing-cidr: "{{ cilium_native_routing_cidr }}"
+  auto-direct-node-routes: "{{ cilium_auto_direct_node_routes }}"

--- a/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-deploy.yml.j2
@@ -20,6 +20,11 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+{% if cilium_enable_prometheus %}
+      annotations:
+        prometheus.io/port: "6942"
+        prometheus.io/scrape: "true"
+{% endif %}
       labels:
         io.cilium/app: operator
         name: cilium-operator
@@ -93,6 +98,13 @@ spec:
           image: "{{ cilium_operator_image_repo }}:{{ cilium_operator_image_tag }}"
           imagePullPolicy: {{ k8s_image_pull_policy }}
           name: cilium-operator
+{% if cilium_enable_prometheus %}
+          ports:
+            - containerPort: 6942
+              hostPort: 6942
+              name: prometheus
+              protocol: TCP
+{% endif %}
           livenessProbe:
             httpGet:
 {% if cilium_enable_ipv4 %}

--- a/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
+++ b/roles/network_plugin/cilium/templates/cilium-ds.yml.j2
@@ -85,11 +85,19 @@ spec:
           successThreshold: 1
           timeoutSeconds: 5
         name: cilium-agent
-{% if cilium_enable_prometheus %}
+{% if cilium_enable_prometheus or cilium_enable_hubble_metrics %}
         ports:
+{% endif %}
+{% if cilium_enable_prometheus %}
         - containerPort: 9090
           hostPort: 9090
           name: prometheus
+          protocol: TCP
+{% endif %}
+{% if cilium_enable_hubble_metrics %}
+        - containerPort: 9091
+          hostPort: 9091
+          name: hubble-metrics
           protocol: TCP
 {% endif %}
         readinessProbe:

--- a/roles/network_plugin/weave/templates/weave-net.yml.j2
+++ b/roles/network_plugin/weave/templates/weave-net.yml.j2
@@ -181,7 +181,7 @@ items:
                   port: 6784
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
@@ -199,6 +199,7 @@ items:
                   mountPath: /lib/modules
                 - name: xtables-lock
                   mountPath: /run/xtables.lock
+                  readOnly: false
             - name: weave-npc
               env:
                 - name: HOSTNAME
@@ -210,12 +211,13 @@ items:
               imagePullPolicy: {{ k8s_image_pull_policy }}
               resources:
                 requests:
-                  cpu: 10m
+                  cpu: 50m
               securityContext:
                 privileged: true
               volumeMounts:
                 - name: xtables-lock
                   mountPath: /run/xtables.lock
+                  readOnly: false
           hostNetwork: true
           dnsPolicy: ClusterFirstWithHostNet
           hostPID: true

--- a/roles/upgrade/pre-upgrade/tasks/main.yml
+++ b/roles/upgrade/pre-upgrade/tasks/main.yml
@@ -30,40 +30,46 @@
       false
       {%- endif %}
 
-- name: Cordon node
-  command: "{{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(inventory_hostname) }}"
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  when: needs_cordoning
+- name: Node draining
+  block:
+    - name: Cordon node
+      command: "{{ bin_dir }}/kubectl cordon {{ kube_override_hostname|default(inventory_hostname) }}"
+      delegate_to: "{{ groups['kube-master'][0] }}"
 
-- name: Check kubectl version
-  command: "{{ bin_dir }}/kubectl version --client --short"
-  register: kubectl_version
-  delegate_to: "{{ groups['kube-master'][0] }}"
-  run_once: yes
-  changed_when: false
-  when:
-    - drain_nodes
-    - needs_cordoning
-    - drain_pod_selector
+    - name: Check kubectl version
+      command: "{{ bin_dir }}/kubectl version --client --short"
+      register: kubectl_version
+      delegate_to: "{{ groups['kube-master'][0] }}"
+      run_once: yes
+      changed_when: false
+      when:
+        - drain_nodes
+        - drain_pod_selector
 
-- name: Ensure minimum version for drain label selector if necessary
-  assert:
-    that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
-  when:
-    - drain_nodes
-    - needs_cordoning
-    - drain_pod_selector
+    - name: Ensure minimum version for drain label selector if necessary
+      assert:
+        that: "kubectl_version.stdout.split(' ')[-1] is version('v1.10.0', '>=')"
+      when:
+        - drain_nodes
+        - drain_pod_selector
 
-- name: Drain node
-  command: >-
-    {{ bin_dir }}/kubectl drain
-    --force
-    --ignore-daemonsets
-    --grace-period {{ drain_grace_period }}
-    --timeout {{ drain_timeout }}
-    --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
-    {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+    - name: Drain node
+      command: >-
+        {{ bin_dir }}/kubectl drain
+        --force
+        --ignore-daemonsets
+        --grace-period {{ drain_grace_period }}
+        --timeout {{ drain_timeout }}
+        --delete-local-data {{ kube_override_hostname|default(inventory_hostname) }}
+        {% if drain_pod_selector %}--pod-selector '{{ drain_pod_selector }}'{% endif %}
+      when:
+        - drain_nodes
+  rescue:
+    - name: Set node back to schedulable
+      command: "{{ bin_dir }}/kubectl --kubeconfig /etc/kubernetes/admin.conf uncordon {{ inventory_hostname }}"
+    - name: Fail after rescue
+      fail:
+        msg: "Failed to drain node {{ inventory_hostname }}"
   delegate_to: "{{ groups['kube-master'][0] }}"
   when:
-    - drain_nodes
     - needs_cordoning

--- a/scale.yml
+++ b/scale.yml
@@ -30,7 +30,7 @@
   gather_facts: false
   roles:
     - { role: kubespray-defaults }
-    - { role: bootstrap-os, tags: bootstrap-os}
+    - { role: bootstrap-os, tags: bootstrap-os }
 
 - name: Gather facts
   tags: always
@@ -46,13 +46,14 @@
 
 - name: Download images to ansible host cache via first kube-master node
   hosts: kube-master[0]
+  gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
   roles:
-    - { role: kubespray-defaults, when: "not skip_downloads and download_run_once and not download_localhost"}
+    - { role: kubespray-defaults, when: "not skip_downloads and download_run_once and not download_localhost" }
     - { role: kubernetes/preinstall, tags: preinstall, when: "not skip_downloads and download_run_once and not download_localhost" }
     - { role: download, tags: download, when: "not skip_downloads and download_run_once and not download_localhost" }
 
-- name: Target only workers to get kubelet installed and checking in on any new nodes
+- name: Target only workers to get kubelet installed and checking in on any new nodes(engine)
   hosts: kube-node
   gather_facts: False
   any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
@@ -62,7 +63,23 @@
     - { role: container-engine, tags: "container-engine", when: deploy_container_engine|default(true) }
     - { role: download, tags: download, when: "not skip_downloads" }
     - { role: etcd, tags: etcd, etcd_cluster_setup: false, when: "not etcd_kubeadm_enabled|default(false)" }
+  environment: "{{ proxy_env }}"
+
+- name: Target only workers to get kubelet installed and checking in on any new nodes(node)
+  hosts: kube-node
+  gather_facts: False
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults }
     - { role: kubernetes/node, tags: node }
+  environment: "{{ proxy_env }}"
+
+- name: Target only workers to get kubelet installed and checking in on any new nodes(network)
+  hosts: kube-node
+  gather_facts: False
+  any_errors_fatal: "{{ any_errors_fatal | default(true) }}"
+  roles:
+    - { role: kubespray-defaults }
     - { role: kubernetes/kubeadm, tags: kubeadm }
     - { role: network_plugin, tags: network }
     - { role: kubernetes/node-label, tags: node-label }

--- a/tests/testcases/100_check-k8s-conformance.yml
+++ b/tests/testcases/100_check-k8s-conformance.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: kube-master[0]
   vars:
-    sonobuoy_version: 0.16.0
+    sonobuoy_version: 0.18.4
     sonobuoy_arch: amd64
     sonobuoy_parallel: 30
     sonobuoy_path: /usr/local/bin/sonobuoy


### PR DESCRIPTION
Signed-off-by: Kuralamudhan Ramakrishnan <kuralamudhan.ramakrishnan@intel.com>

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This provides an easier way to install ovn4nfv-k8s-plugins as the network plugin in Kubespray. [ovn4nfv-k8s-plugins](https://github.com/opnfv/ovn4nfv-k8s-plugin) is the network controller, OVS agent and CNI server to offer basic SFC and OVN overlay networking.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Add kube_network_plugin: ovn4nfv to deploy ovn4nfv-k8s-plugin as network plugin in kubespray
```